### PR TITLE
Re-generate outdated proto files.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,21 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e292605effc7da39b7a8734c719afb12ec4b5362add3528d8afad3aa3aa9057c
+  url: https://github.com/GoogleCloudPlatform/grpc-gcp-python/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 44de25348f489920efb3b1a05134816cfbc3e880fa92e3a7b4dfcb7e772ac625
 
 build:
-  number: 3
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  number: 4
+  script:
+    - cp template/version.py src/
+    - cp src/LICENSE .
+    - cd src
+    - python -m grpc_tools.protoc -I. --python_out=./grpc_gcp/proto --grpc_python_out=./grpc_gcp/proto grpc_gcp.proto
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - grpcio-tools
   host:
     - python
     - pip


### PR DESCRIPTION
grpcio-gcp rebuild

**Destination channel:**  defaults

### Links

- [PKG-7503](https://anaconda.atlassian.net/browse/PKG-7503 
- [Upstream repository](https://github.com/GoogleCloudPlatform/grpc-gcp-python)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - Fixes https://github.com/AnacondaRecipes/google-api-core-feedstock/pull/19

### Explanation of changes:

Currently building this package, or having it as dependency results in:

```
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
```

- Change src url to github in order to get the [.proto file](https://github.com/GoogleCloudPlatform/grpc-gcp-python/blob/master/src/grpc_gcp.proto) that is needed to regenerate [grpc_gcp_pb2.py](https://github.com/GoogleCloudPlatform/grpc-gcp-python/blob/master/src/grpc_gcp/proto/grpc_gcp_pb2.py) with our latest protobuf. 


[PKG-7502]: https://anaconda.atlassian.net/browse/PKG-7502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-7503]: https://anaconda.atlassian.net/browse/PKG-7503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ