### PR TITLE
Set upper bound on protobuf.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 4
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py>=313]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e292605effc7da39b7a8734c719afb12ec4b5362add3528d8afad3aa3aa9057c
 
 build:
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - grpcio >=1.16.0
-    - protobuf >=3.6.1
+    - protobuf >=3.6.1,<3.21
 
 test:
   requires:


### PR DESCRIPTION
grpcio-gcp rebuild

**Destination channel:**  defaults

### Links

- [PKG-7503](https://anaconda.atlassian.net/browse/PKG-7503)
- [Upstream repository](https://github.com/GoogleCloudPlatform/grpc-gcp-python)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - Fixes https://github.com/AnacondaRecipes/google-api-core-feedstock/pull/19

### Explanation of changes:

Currently building this package, or having it as dependency results in:

```
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
```

- limit probuf to 3.20.x or lower
- Skip for 3.13 since there is no old protobuf available.

[PKG-7502]: https://anaconda.atlassian.net/browse/PKG-7502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-7503]: https://anaconda.atlassian.net/browse/PKG-7503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ